### PR TITLE
Change box to 'hashicorp/precise64' and modify bootstrap script.

### DIFF
--- a/app/Vagrantfile
+++ b/app/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure(2) do |config|
-    config.vm.box = "ubuntu/trusty64"
+    config.vm.box = "hashicorp/precise64"
     config.vm.synced_folder "./", "/home/vagrant/app"
     config.vm.network "forwarded_port", guest: 3000, host: 12804
     config.vm.provision :shell, :path => "setup.sh"

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -1,6 +1,7 @@
 sudo apt-get -y update
-sudo apt-get -y install build-essential
+sudo apt-get -y install build-essential curl
 curl -so node.tar.gz https://nodejs.org/dist/v4.2.6/node-v4.2.6-linux-x64.tar.xz
 sudo tar -C /usr/local --strip-components 1 -xvf node.tar.gz && rm node.tar.gz
 sudo npm install node-pre-gyp -g
-cd app && npm install --no-bin-links
+sudo adduser vagrant dialout
+cd /home/vagrant/app && npm install --no-bin-links


### PR DESCRIPTION
'ubuntu/trusty64' does not have the cdc_acm kernel module by default.
